### PR TITLE
feat: 주문 확인 페이지 구현 및 백엔드 연동

### DIFF
--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "axios": "^1.13.6",
         "next": "16.2.1",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -2392,6 +2393,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
@@ -2453,6 +2460,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2575,7 +2593,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2674,6 +2691,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2833,6 +2862,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2860,7 +2898,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2972,7 +3009,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2982,7 +3018,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3021,7 +3056,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3034,7 +3068,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3655,6 +3688,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3669,6 +3722,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -3689,7 +3758,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3750,7 +3818,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3775,7 +3842,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3863,7 +3929,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3935,7 +4000,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3948,7 +4012,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3964,7 +4027,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4947,7 +5009,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4975,6 +5036,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -5472,6 +5554,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "axios": "^1.13.6",
     "next": "16.2.1",
     "react": "19.2.4",
     "react-dom": "19.2.4"

--- a/Frontend/src/app/orders/page.tsx
+++ b/Frontend/src/app/orders/page.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useSearchParams, useRouter } from "next/navigation";
+import { useState, useEffect } from "react";
+import { createOrderApi } from "@/lib/client";
+import { getProducts } from "@/lib/products"; // [추가] 백엔드에서 상품을 가져오는 함수
+import { Product } from "@/type/product";     // 상품 타입
+
+interface FinalOrderItem {
+  productId: number;
+  name: string;
+  price: number;
+  quantity: number;
+}
+
+export default function OrderConfirmPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  // 1. URL에서 넘어온 기본 고객 정보
+  const email = searchParams.get("email") || "";
+  const address = searchParams.get("address") || "";
+  const postcode = searchParams.get("postalCode") || "";
+
+  // 2. 상태 관리 (선택된 상품들)
+  const [finalItems, setFinalItems] = useState<FinalOrderItem[]>([]);
+
+  // [수정] 페이지가 열리자마자 백엔드에서 전체 상품 목록을 가져와서 매칭합니다.
+  useEffect(() => {
+    const initOrderData = async () => {
+      // (1) 백엔드에서 실제 상품 리스트를 가져옵니다.
+      const realProducts: Product[] = await getProducts();
+
+      // (2) URL에 담긴 선택된 상품 ID와 수량 정보를 가져옵니다.
+      const productsParam = searchParams.get("products");
+
+      if (productsParam && realProducts.length > 0) {
+        try {
+          const parsedSelected = JSON.parse(productsParam);
+
+          // (3) 백엔드 데이터와 선택된 정보를 합칩니다.
+          const mergedItems = parsedSelected.map((selected: any) => {
+            // 백엔드 데이터(realProducts)에서 ID가 같은 상품을 찾습니다.
+            const productInfo = realProducts.find(p => p.id === selected.productId);
+
+            return {
+              productId: selected.productId,
+              name: productInfo?.name || "알 수 없는 상품",
+              price: productInfo?.price || 0,
+              quantity: selected.quantity,
+            };
+          });
+
+          setFinalItems(mergedItems);
+        } catch (e) {
+          console.error("데이터 매칭 실패", e);
+        }
+      }
+    };
+
+    initOrderData();
+  }, [searchParams]);
+
+  // 수량 증감 함수 (기존과 동일)
+  const updateQuantity = (productId: number, delta: number) => {
+    setFinalItems((prev) =>
+      prev.map((item) =>
+        item.productId === productId
+          ? { ...item, quantity: Math.max(1, item.quantity + delta) }
+          : item
+      )
+    );
+  };
+
+  // 총액 계산
+  const totalProductPrice = finalItems.reduce((acc, curr) => acc + curr.price * curr.quantity, 0);
+
+  // 최종 주문하기 (기존과 동일)
+  const handleFinalOrder = async () => {
+    try {
+      const requestData = {
+        email,
+        address,
+        postcode,
+        orderItems: finalItems.map(item => ({
+          productId: item.productId,
+          quantity: item.quantity
+        }))
+      };
+
+      await createOrderApi(requestData);
+      alert("주문이 성공적으로 완료되었습니다!");
+      router.push("/");
+    } catch (error) {
+      alert("주문 처리 중 오류가 발생했습니다.");
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto p-6 bg-white min-h-screen">
+      <h1 className="text-2xl font-bold mb-8">주문하기</h1>
+
+      {/* 고객 정보 */}
+      <div className="mb-10">
+        <h2 className="text-lg font-semibold mb-4">고객 정보</h2>
+        <div className="bg-gray-50 p-4 rounded-lg space-y-2">
+          <p><strong>이메일:</strong> {email}</p>
+          <p><strong>주소:</strong> {address}</p>
+          <p><strong>우편번호:</strong> {postcode}</p>
+        </div>
+      </div>
+
+      {/* 주문 상품 */}
+      <div className="mb-10">
+        <h2 className="text-lg font-semibold mb-4">주문 상품</h2>
+        <div className="border border-gray-200 rounded-lg p-4 space-y-3">
+          {finalItems.length === 0 ? (
+            <p className="text-gray-400">불러오는 중...</p>
+          ) : (
+            finalItems.map((item) => (
+              <div key={item.productId} className="flex justify-between items-center pb-3 border-b border-gray-100 last:border-b-0">
+                <div>
+                  <p className="font-medium">{item.name}</p>
+                  <p className="text-sm text-gray-500">₩{item.price.toLocaleString()}</p>
+                </div>
+                <div className="flex items-center gap-2 border rounded p-1 bg-white">
+                  <button onClick={() => updateQuantity(item.productId, -1)} className="px-2 hover:bg-gray-100">-</button>
+                  <span className="font-bold w-6 text-center">{item.quantity}</span>
+                  <button onClick={() => updateQuantity(item.productId, 1)} className="px-2 hover:bg-gray-100">+</button>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* 합계 및 주문 버튼 */}
+      <div className="mb-10 border-t pt-6 text-right">
+        <p className="text-2xl font-bold">총합: ₩{totalProductPrice.toLocaleString()}</p>
+      </div>
+
+      <button
+        onClick={handleFinalOrder}
+        className="w-full bg-gray-900 text-white py-4 rounded-xl font-bold text-xl hover:bg-black transition-all"
+      >
+        주문하기
+      </button>
+    </div>
+  );
+}

--- a/Frontend/src/components/OrderSidebar.tsx
+++ b/Frontend/src/components/OrderSidebar.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation"; // 수정: next/router 대신 next/navigation 사용
 import { Product } from "@/type/product";
 import { OrderProduct } from "@/type/orderProduct";
-import { Order } from "@/type/order";
 import CartBadge from "./CartBadge";
-import router from "next/router";
 
 interface OrderSidebarProps {
   cart: OrderProduct[];
@@ -13,6 +12,8 @@ interface OrderSidebarProps {
 }
 
 export default function OrderSidebar({ cart, products }: OrderSidebarProps) {
+  // 수정: App Router 방식의 useRouter 훅 사용
+  const router = useRouter();
   const [form, setForm] = useState({ email: "", address: "", postalCode: "" });
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) =>
@@ -25,7 +26,7 @@ export default function OrderSidebar({ cart, products }: OrderSidebarProps) {
       product: products.find((p) => p.id === item.productId)!,
     }));
 
-  const handleOrder = () => {
+  const handleOrder = async () => {
     if (!form.email || !form.address || !form.postalCode) {
       alert("모든 항목을 입력해주세요.");
       return;
@@ -35,16 +36,19 @@ export default function OrderSidebar({ cart, products }: OrderSidebarProps) {
       return;
     }
 
-    // 3. 주문 데이터를 쿼리 문자열로 변환
+
     const query = new URLSearchParams({
       email: form.email,
       address: form.address,
       postalCode: form.postalCode,
-      products: JSON.stringify(filledCart.map(({ productId, quantity }) => ({ productId, quantity })))
+      // 상품 ID와 수량 정보만 JSON 문자열로 변환하여 전달
+      products: JSON.stringify(
+        filledCart.map(({ productId, quantity }) => ({ productId, quantity }))
+      )
     }).toString();
-    
-    // 4. 주문 내역 페이지로 이동 (쿼리 포함)
-    router.push(`/orders?${query}`); 
+
+    // 3. 주문 확인 페이지(/orders)로 이동
+    router.push(`/orders?${query}`);
   };
 
   const fields = [
@@ -64,7 +68,7 @@ export default function OrderSidebar({ cart, products }: OrderSidebarProps) {
           <ul className="flex flex-col gap-2">
             {filledCart.map(({ productId, quantity, product }) => (
               <li key={productId} className="flex items-center justify-between text-sm">
-                <span className="text-gray-700">{product.name}</span>
+                <span className="text-gray-700">{product?.name || "상품 정보 없음"}</span>
                 <CartBadge count={quantity} />
               </li>
             ))}
@@ -78,7 +82,7 @@ export default function OrderSidebar({ cart, products }: OrderSidebarProps) {
               <input
                 type={type}
                 name={name}
-                value={form[name]}
+                value={form[name as keyof typeof form]}
                 onChange={handleChange}
                 placeholder={placeholder}
                 className="rounded border border-gray-300 bg-white px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-gray-400 transition"

--- a/Frontend/src/lib/client.ts
+++ b/Frontend/src/lib/client.ts
@@ -5,9 +5,10 @@ export function fetchApi<T>(url: string, options?: RequestInit): Promise<T> {
         options.headers = headers;
     }
 
-    return fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}${url}`, options).then(
+    // 환경변수 대신 직접 주소 입력
+    return fetch(`http://localhost:8080${url}`, options).then(
         async (res) => {
-            if (!res.ok) { // 200
+            if (!res.ok) {
                 const rsData = await res.json();
                 throw new Error(rsData.msg || "요청 실패");
             }
@@ -15,3 +16,10 @@ export function fetchApi<T>(url: string, options?: RequestInit): Promise<T> {
         }
     )
 }
+
+export const createOrderApi = async (orderData: any) => {
+        return fetchApi("/api/orders", {
+            method: "POST",
+            body: JSON.stringify(orderData),
+        });
+    };

--- a/Frontend/src/lib/products.ts
+++ b/Frontend/src/lib/products.ts
@@ -1,36 +1,19 @@
 import { Product } from "@/type/product";
 
-export const products: Product[] = [
-  {
-    id: 1,
-    name: "Ethiopian Yirgacheffe",
-    origin: "Ethiopia",
-    weight: "250g",
-    description: "Floral and citrus notes with a smooth, tea-like body.",
-    price: 18000,
-  },
-  {
-    id: 2,
-    name: "Colombian Supremo",
-    origin: "Colombia",
-    weight: "250g",
-    description: "Rich, balanced flavor with caramel sweetness and mild acidity.",
-    price: 16000,
-  },
-  {
-    id: 3,
-    name: "Brazil Santos",
-    origin: "Brazil",
-    weight: "250g",
-    description: "Nutty and chocolatey with low acidity and a creamy finish.",
-    price: 15000,
-  },
-  {
-    id: 4,
-    name: "Guatemala Antigua",
-    origin: "Guatemala",
-    weight: "250g",
-    description: "Complex with hints of cocoa and spice, full-bodied richness.",
-    price: 17000,
-  },
-];
+
+export const getProducts = async (): Promise<Product[]> => {
+  try {
+    // 8080 포트(백엔드)에서 진짜 상품 리스트를 가져오는 명령
+    const response = await fetch("http://localhost:8080/api/products/list");
+
+    if (!response.ok) {
+      throw new Error("상품 목록 로딩 실패");
+    }
+
+    // 서버가 준 정보를 JSON(컴퓨터용 데이터 형식)으로 변환해서 반환
+    return await response.json();
+  } catch (error) {
+    console.error("데이터를 가져오는 중 에러 발생:", error);
+    return []; // 에러가 나면 빈 목록을 보내서 화면이 멈추지 않게 만듬
+  }
+};

--- a/Frontend/src/type/order.ts
+++ b/Frontend/src/type/order.ts
@@ -6,3 +6,16 @@ export interface Order {
   postalCode: string;
   products: OrderProduct[];
 }
+
+//
+export interface OrderItem {
+  productId: number;
+  quantity: number;
+}
+
+export interface OrderCreateRequest {
+  email: string;
+  address: string;
+  postcode: string;
+  orderItems: OrderItem[];
+}


### PR DESCRIPTION
## 👩‍💻 요구 사항과 구현 내용
1. 주문 확인 페이지 (/orders) 구현
데이터 연동: URL 쿼리 파라미터(email, address, products)를 파싱하여 화면에 자동 렌더링
수량 조절: 주문 확인 단계에서 상품별 수량 증감(+, -) 및 실시간 총 금액 계산 기능
최종 주문: '주문하기' 클릭 시 백엔드 DB에 데이터 저장 및 메인 페이지 리다이렉트

2. 프론트엔드-백엔드 API 연동 강화
src/lib/products.ts: 하드코딩된 임시 데이터를 제거하고, getProducts 함수를 통해 백엔드(:8080)의 실시간 상품 목록을 가져오도록 수정
src/lib/client.ts: 주문 생성을 위한 createOrderApi 함수 추가 및 API 호출 주소 최적화
오류 해결: API Base URL이 undefined로 읽히는 문제를 해결하기 위해 절대 경로를 적용하여 통신 안정성 확보

3. 기술적 수정 및 개선
라우팅 방식 수정: Next.js App Router 환경에 맞게 next/router를 next/navigation의 useRouter로 전면 교체 (Runtime Error 해결)
파일 충돌 해결: main 브랜치 병합 과정에서 발생한 products.ts 파일의 삭제/수정 충돌을 해결하고 최신 로직으로 복구