### PR TITLE
fix: product와 orderitem 엔티티간의 외래키 문제 해결

### DIFF
--- a/Backend/src/main/java/com/decaf/domain/product/entity/Product.java
+++ b/Backend/src/main/java/com/decaf/domain/product/entity/Product.java
@@ -1,11 +1,17 @@
 package com.decaf.domain.product.entity;
 
+import com.decaf.domain.orderItem.entity.OrderItem;
 import com.decaf.global.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -28,6 +34,9 @@ public class Product extends BaseEntity {
   @Column(nullable = false, length = 512)
   private String imgUrl;
 
+  @OneToMany(mappedBy = "product", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  private List<OrderItem> orderItems = new ArrayList<>();
+
   // 이 메서드를 통해 Service에서 수정가능 + JPA에 더티체킹
   public void update(String name, String category, Integer price, String description,String imgUrl) {
     this.name = name;
@@ -35,6 +44,16 @@ public class Product extends BaseEntity {
     this.category = category;
     this.description = description;
     this.imgUrl = imgUrl;
+
+  }
+
+  public Product(String name, String category, Integer price, String description, String imgUrl) {
+    this.name = name;
+    this.category = category;
+    this.price = price;
+    this.description = description;
+    this.imgUrl = imgUrl;
+    this.orderItems = new ArrayList<>();
   }
 
 }

--- a/Backend/src/main/java/com/decaf/domain/product/service/ProductService.java
+++ b/Backend/src/main/java/com/decaf/domain/product/service/ProductService.java
@@ -51,7 +51,6 @@ public class ProductService {
     public void delete(Integer id) {
         Product product = productRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품입니다. id=" + id));
-
         productRepository.delete(product);
     }
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- product 엔티티에서 orderitem 외래키를 설정하지 않아서 상품이 삭제가 되지 않던 문제가 있었습니다.
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 이를 해결하기 위해 product 엔티티에서 외래키를 설정하고, CascadeType.REMOVE, orphanRemoval = true 를 적용하여 삭제가 되게 만들었습니다.
## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
